### PR TITLE
Improves base64 format iOS and updates documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ CameraPreview.show();
 CameraPreview.hide();
 ```
 
-<b>Base64 image:</b><br/>
-Use the cordova-file in order to read the picture file and them get the base64.<br/>
-Please, refer to this documentation: http://docs.phonegap.com/en/edge/cordova_file_file.md.html<br/>
-Method <i>readAsDataURL</i>: Read file and return data as a base64-encoded data URL.
-
-
 <b>IOS Quirks:</b><br/>
 It is not possible to use your computers webcam during testing in the simulator, you must device test.
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,11 @@ CameraPreview.takePicture({maxWidth:640, maxHeight:640});
 
 
 <b>setOnPictureTakenHandler(callback)</b><br/>
-<info>Register a callback function that receives the original picture and the image captured from the preview box.</info><br/>
+<info>Register a callback function that receives the image captured from the preview box.</info><br/>
 
 ```javascript
-CameraPreview.setOnPictureTakenHandler(function(result){
-  document.getElementById('originalPicture').src = result[0]; //originalPicturePath;
-  document.getElementById('previewPicture').src = result[1]; //previewPicturePath;
+CameraPreview.setOnPictureTakenHandler(function (picture) {
+  document.getElementById('picture').src = picture; // base64 picture;
 });
 ```
 

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -201,7 +201,7 @@
 
             capturedImage = [self imageCorrectedForCaptureOrientation:capturedImage];
 
-            NSString *originalPicture = [UIImageJPEGRepresentation(capturedImage, 0.75f) base64EncodedStringWithOptions:0];
+            NSString *originalPicture = [NSString stringWithFormat:@"data:image/jpeg;base64,%@", [UIImageJPEGRepresentation(capturedImage, 0.75f) base64EncodedStringWithOptions:0]];
 
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:originalPicture];
             [pluginResult setKeepCallbackAsBool:true];


### PR DESCRIPTION
Hey,

I think it's more logical to include the header into the base64 format. I also updated the documentation according to the current iOS code (I do not have checked the Android one).
