### PR TITLE
[Android] use maxWidth/maxHeight to scale the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ idea
 npm-debug.log
 node_modules/
 bower_components/
+*.iml

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,6 +16,9 @@
   <platform name="android">
     <source-file src="src/android/CameraPreview.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/CameraActivity.java" target-dir="src/com/cordovaplugincamerapreview" />
+    <source-file src="src/android/CustomSurfaceView.java" target-dir="src/com/cordovaplugincamerapreview" />
+    <source-file src="src/android/Preview.java" target-dir="src/com/cordovaplugincamerapreview" />
+    <source-file src="src/android/TapGestureDetector.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/camera_activity.xml" target-dir="res/layout" />
     <source-file src="src/android/camera_theme.xml" target-dir="res/values" />
     <source-file src="src/android/camera_ids.xml" target-dir="res/values" />

--- a/src/android/CameraActivity.java
+++ b/src/android/CameraActivity.java
@@ -1,849 +1,569 @@
 package com.cordovaplugincamerapreview;
 
-import android.app.Activity;
 import android.app.Fragment;
-import android.content.Context;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
-import android.graphics.ImageFormat;
 import android.graphics.Matrix;
-import android.graphics.Rect;
-import android.graphics.YuvImage;
 import android.hardware.Camera;
-import android.hardware.Camera.PictureCallback;
 import android.hardware.Camera.Parameters;
+import android.hardware.Camera.PictureCallback;
 import android.os.Bundle;
-import android.util.Log;
-import android.util.DisplayMetrics;
 import android.util.Base64;
-import android.view.GestureDetector;
-import android.view.Gravity;
-import android.view.LayoutInflater;
-import android.view.MotionEvent;
-import android.view.Surface;
-import android.view.SurfaceHolder;
-import android.view.SurfaceView;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
+import android.util.Log;
+import android.view.*;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
-import org.apache.cordova.LOG;
-
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 
 public class CameraActivity extends Fragment {
+    private static final int FLASH_OFF = 0;
+    private static final int FLASH_ON = 1;
+    private static final int FLASH_AUTO = 2;
+    private static final int FOCUS_AUTO = 0;
+    private static final int FOCUS_CONTINUOUS = 1;
+    private static final String TAG = "CameraActivity";
+    String defaultCamera;
+    boolean tapToTakePicture;
+    boolean dragEnabled;
+    private CameraPreviewListener eventListener;
+    private FrameLayout frameContainerLayout;
+    private Preview mPreview;
+    private boolean canTakePicture = true;
+    private View view;
+    private Camera.Parameters cameraParameters;
+    private Camera mCamera;
+    private int numberOfCameras;
+    private int cameraCurrentlyLocked;
+    // The first rear facing camera
+    private int defaultCameraId;
+    private int width;
+    private int height;
+    private int x;
+    private int y;
+    private String appResourcesPackage;
+    private int currentFlashMode = FLASH_OFF;
+    private int currentFocusMode = FOCUS_AUTO;
 
-  public interface CameraPreviewListener {
-    public void onPictureTaken(String originalPicturePath);
-  }
-
-  private static final int FLASH_OFF = 0;
-  private static final int FLASH_ON = 1;
-  private static final int FLASH_AUTO = 2;
-
-  public int currentFlashMode = 2;
-
-  private static final int FOCUS_AUTO = 0;
-  private static final int FOCUS_CONTINUOUS = 1;
-
-  public int currentFocusMode = 0;
-
-  private CameraPreviewListener eventListener;
-  private static final String TAG = "CameraActivity";
-  public FrameLayout mainLayout;
-  public FrameLayout frameContainerLayout;
-
-  private Preview mPreview;
-  private boolean canTakePicture = true;
-
-  private View view;
-  private Camera.Parameters cameraParameters;
-  private Camera mCamera;
-  private int numberOfCameras;
-  private int cameraCurrentlyLocked;
-
-  // The first rear facing camera
-  private int defaultCameraId;
-  public String defaultCamera;
-  public boolean tapToTakePicture;
-  public boolean dragEnabled;
-
-  public int width;
-  public int height;
-  public int x;
-  public int y;
-
-  public void setEventListener(CameraPreviewListener listener){
-    eventListener = listener;
-  }
-
-  private String appResourcesPackage;
-
-  @Override
-  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-    appResourcesPackage = getActivity().getPackageName();
-
-    // Inflate the layout for this fragment
-    view = inflater.inflate(getResources().getIdentifier("camera_activity", "layout", appResourcesPackage), container, false);
-    createCameraPreview();
-    return view;
-  }
-
-  @Override
-  public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-  }
-  public void setRect(int x, int y, int width, int height){
-    this.x = x;
-    this.y = y;
-    this.width = width;
-    this.height = height;
-  }
-
-  private void createCameraPreview(){
-    if(mPreview == null) {
-      setDefaultCameraId();
-
-      //set box position and size
-      FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(width, height);
-      layoutParams.setMargins(x, y, 0, 0);
-      frameContainerLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
-      frameContainerLayout.setLayoutParams(layoutParams);
-
-      //video view
-      mPreview = new Preview(getActivity());
-      mainLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("video_view", "id", appResourcesPackage));
-      mainLayout.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT));
-      mainLayout.addView(mPreview);
-      mainLayout.setEnabled(false);
-
-      final GestureDetector gestureDetector = new GestureDetector(getActivity().getApplicationContext(), new TapGestureDetector());
-
-      getActivity().runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          frameContainerLayout.setClickable(true);
-          frameContainerLayout.setOnTouchListener(new View.OnTouchListener() {
-
-            private int mLastTouchX;
-            private int mLastTouchY;
-            private int mPosX = 0;
-            private int mPosY = 0;
-
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-              FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
-
-
-              boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
-              if (event.getAction() != MotionEvent.ACTION_MOVE && isSingleTapTouch) {
-                if (tapToTakePicture) {
-                  takePicture(0, 0);
-                }
-                return true;
-              }
-              else {
-                if (dragEnabled) {
-                  int x;
-                  int y;
-
-                  switch (event.getAction()) {
-                    case MotionEvent.ACTION_DOWN:
-                      if(mLastTouchX == 0 || mLastTouchY == 0) {
-                        mLastTouchX = (int)event.getRawX() - layoutParams.leftMargin;
-                        mLastTouchY = (int)event.getRawY() - layoutParams.topMargin;
-                      }
-                      else{
-                        mLastTouchX = (int)event.getRawX();
-                        mLastTouchY = (int)event.getRawY();
-                      }
-                      break;
-                    case MotionEvent.ACTION_MOVE:
-
-                      x = (int) event.getRawX();
-                      y = (int) event.getRawY();
-
-                      final float dx = x - mLastTouchX;
-                      final float dy = y - mLastTouchY;
-
-                      mPosX += dx;
-                      mPosY += dy;
-
-                      layoutParams.leftMargin = mPosX;
-                      layoutParams.topMargin = mPosY;
-
-                      frameContainerLayout.setLayoutParams(layoutParams);
-
-                      // Remember this touch position for the next move event
-                      mLastTouchX = x;
-                      mLastTouchY = y;
-
-                      break;
-                    default:
-                      break;
-                  }
-                }
-              }
-              return true;
-            }
-          });
-        }
-      });
-    }
-  }
-
-  private void setDefaultCameraId(){
-
-    // Find the total number of cameras available
-    numberOfCameras = Camera.getNumberOfCameras();
-
-    int camId = defaultCamera.equals("front") ? Camera.CameraInfo.CAMERA_FACING_FRONT : Camera.CameraInfo.CAMERA_FACING_BACK;
-
-    // Find the ID of the default camera
-    Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
-    for (int i = 0; i < numberOfCameras; i++) {
-      Camera.getCameraInfo(i, cameraInfo);
-      if (cameraInfo.facing == camId) {
-        defaultCameraId = camId;
-        break;
-      }
-    }
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-
-    mCamera = Camera.open(defaultCameraId);
-
-    if (cameraParameters != null) {
-      mCamera.setParameters(cameraParameters);
+    void setEventListener(CameraPreviewListener listener) {
+        eventListener = listener;
     }
 
-    // set continuous autofocus
-    setFocusMode(FOCUS_CONTINUOUS);
-    
-    cameraCurrentlyLocked = defaultCameraId;
-
-    if(mPreview.mPreviewSize == null){
-      mPreview.setCamera(mCamera, cameraCurrentlyLocked);
-    } else {
-      mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
-      mCamera.startPreview();
-    }
-
-    Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
-
-    final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
-    ViewTreeObserver viewTreeObserver = frameContainerLayout.getViewTreeObserver();
-    if (viewTreeObserver.isAlive()) {
-      viewTreeObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-        @Override
-        public void onGlobalLayout() {
-          frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-          frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
-          final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage));
-
-          FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(frameContainerLayout.getWidth(), frameContainerLayout.getHeight());
-          camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
-          frameCamContainerLayout.setLayoutParams(camViewLayout);
-        }
-      });
-    }
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-
-    // Because the Camera object is a shared resource, it's very
-    // important to release it when the activity is paused.
-    if (mCamera != null) {
-      mPreview.setCamera(null, -1);
-      mCamera.release();
-      mCamera = null;
-    }
-  }
-
-  public Camera getCamera() {
-    return mCamera;
-  }
-
-  public void switchCamera() {
-    // check for availability of multiple cameras
-    if (numberOfCameras == 1) {
-      //There is only one camera available
-    }
-    Log.d(TAG, "numberOfCameras: " + numberOfCameras);
-
-    // OK, we have multiple cameras.
-    // Release this camera -> cameraCurrentlyLocked
-    if (mCamera != null) {
-      mCamera.stopPreview();
-      mPreview.setCamera(null, -1);
-      mCamera.release();
-      mCamera = null;
-    }
-
-    // Acquire the next camera and request Preview to reconfigure
-    // parameters.
-    mCamera = Camera.open((cameraCurrentlyLocked + 1) % numberOfCameras);
-
-    if (cameraParameters != null) {
-      mCamera.setParameters(cameraParameters);
-    }
-
-    cameraCurrentlyLocked = (cameraCurrentlyLocked + 1) % numberOfCameras;
-    mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
-
-    Log.d(TAG, "cameraCurrentlyLocked new: " + cameraCurrentlyLocked);
-
-    // Start the preview
-    mCamera.startPreview();
-  }
-
-  public void setFlashMode(int flashMode) {
-
-    Camera.Parameters parameters = mCamera.getParameters();
-    List<String> supportedFlashModes = parameters.getSupportedFlashModes();
-
-    if (supportedFlashModes != null) {
-      if (flashMode == FLASH_OFF && supportedFlashModes.contains(Parameters.FLASH_MODE_OFF)) {
-        parameters.setFlashMode(Parameters.FLASH_MODE_OFF);
-      } else if (flashMode == FLASH_ON && supportedFlashModes.contains(Parameters.FLASH_MODE_ON)) {
-        parameters.setFlashMode(Parameters.FLASH_MODE_ON);
-      } else if (flashMode == FLASH_AUTO && supportedFlashModes.contains(Parameters.FLASH_MODE_AUTO)) {
-        parameters.setFlashMode(Parameters.FLASH_MODE_AUTO);
-      } else if (flashMode == FLASH_AUTO && supportedFlashModes.contains(Parameters.FLASH_MODE_ON)) {
-        parameters.setFlashMode(Parameters.FLASH_MODE_ON);
-      }
-      mCamera.setParameters(parameters);
-    }
-
-    Log.d(TAG, "flashmode: " + flashMode);
-
-    currentFlashMode = flashMode;
-  }
-
-  public void setFocusMode(int focusMode) {
-    Camera.Parameters parameters = mCamera.getParameters();
-    List<String> supportedFocusModes = parameters.getSupportedFocusModes();
-
-    if(supportedFocusModes != null) {
-      if(focusMode == FOCUS_AUTO && supportedFocusModes.contains(Parameters.FOCUS_MODE_AUTO)){
-        parameters.setFocusMode(Parameters.FOCUS_MODE_AUTO);
-      } else if(focusMode == FOCUS_CONTINUOUS && supportedFocusModes.contains(Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-        parameters.setFocusMode(Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
-      }
-      mCamera.setParameters(parameters);
-    }
-
-    Log.d(TAG, "focusMode: " + focusMode);
-
-    currentFocusMode = focusMode;
-  }
-
-
-  public void setCameraParameters(Camera.Parameters params) {
-    cameraParameters = params;
-
-    if (mCamera != null && cameraParameters != null) {
-      mCamera.setParameters(cameraParameters);
-    }
-  }
-
-  public boolean hasFrontCamera(){
-    return getActivity().getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
-  }
-
-  public Bitmap cropBitmap(Bitmap bitmap, Rect rect){
-    int w = rect.right - rect.left;
-    int h = rect.bottom - rect.top;
-    Bitmap ret = Bitmap.createBitmap(w, h, bitmap.getConfig());
-    Canvas canvas= new Canvas(ret);
-    canvas.drawBitmap(bitmap, -rect.left, -rect.top, null);
-    return ret;
-  }
-
-  public void takePicture(final double maxWidth, final double maxHeight){
-    if(mPreview != null) {
-
-      if(!canTakePicture)
-        return;
-
-      canTakePicture = false;
-
-      mCamera.takePicture(null, null, mPicture);
-
-    }
-    else{
-      canTakePicture = true;
-    }
-  }
-
-  PictureCallback mPicture = new PictureCallback() {
     @Override
-    public void onPictureTaken(byte[] data, Camera camera) {
-      Bitmap picture = BitmapFactory.decodeByteArray(data, 0, data.length);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        appResourcesPackage = getActivity().getPackageName();
 
-      Matrix matrix = new Matrix();
-
-      if (cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-        Log.d(TAG, "mirror y axis");
-        matrix.preScale(-1.0f, 1.0f);
-      }
-
-      matrix.postRotate(mPreview.getDisplayOrientation());
-
-      try
-      {
-        picture = Bitmap.createBitmap(picture, 0, 0, picture.getWidth(), picture.getHeight(), matrix, true);
-
-        // scale it to fit the view
-        final ImageView pictureView = (ImageView) view.findViewById(getResources().getIdentifier("picture_view", "id", appResourcesPackage));
-        float scale = (float) pictureView.getWidth() / (float) picture.getWidth();
-        picture = Bitmap.createScaledBitmap(picture, (int) (picture.getWidth() * scale), (int) (picture.getHeight() * scale), false);
-
-      }
-      catch (OutOfMemoryError oom)
-      {
-        // You can run out of memory if the image is very large:
-        // http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html
-        // If this happens, simply do not rotate the image and return it unmodified.
-        // If you do not catch the OutOfMemoryError, the Android app crashes.
-      }
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      picture.compress(Bitmap.CompressFormat.JPEG, 85, byteArrayOutputStream);
-      byte[] byteArray = byteArrayOutputStream.toByteArray();
-
-      String encodedImage = Base64.encodeToString(byteArray, Base64.NO_WRAP);
-
-      eventListener.onPictureTaken(encodedImage);
-      canTakePicture = true;
+        // Inflate the layout for this fragment
+        view = inflater.inflate(getResources().getIdentifier("camera_activity", "layout", appResourcesPackage), container, false);
+        createCameraPreview();
+        return view;
     }
-  };
 
-  private void generatePictureFromView(final Bitmap originalPicture, final Bitmap picture){
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
 
-    final FrameLayout cameraLoader = (FrameLayout)view.findViewById(getResources().getIdentifier("camera_loader", "id", appResourcesPackage));
-    cameraLoader.setVisibility(View.VISIBLE);
-    final ImageView pictureView = (ImageView) view.findViewById(getResources().getIdentifier("picture_view", "id", appResourcesPackage));
-    new Thread() {
-      public void run() {
+    void setRect(int x, int y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
 
-        try {
-          final File picFile = storeImage(picture, "_preview");
-          final File originalPictureFile = storeImage(originalPicture, "_original");
+    private void createCameraPreview() {
+        if (mPreview == null) {
+            setDefaultCameraId();
 
-          eventListener.onPictureTaken(originalPictureFile.getAbsolutePath());
+            //set box position and size
+            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(width, height);
+            layoutParams.setMargins(x, y, 0, 0);
+            frameContainerLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
+            frameContainerLayout.setLayoutParams(layoutParams);
 
-          getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-              cameraLoader.setVisibility(View.INVISIBLE);
-              pictureView.setImageBitmap(null);
+            //video view
+            mPreview = new Preview(getActivity());
+            FrameLayout mainLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("video_view", "id", appResourcesPackage));
+            mainLayout.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT));
+            mainLayout.addView(mPreview);
+            mainLayout.setEnabled(false);
+
+            final GestureDetector gestureDetector = new GestureDetector(getActivity().getApplicationContext(), new TapGestureDetector());
+
+            getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    frameContainerLayout.setClickable(true);
+                    frameContainerLayout.setOnTouchListener(new View.OnTouchListener() {
+
+                        private int mLastTouchX;
+                        private int mLastTouchY;
+                        private int mPosX = 0;
+                        private int mPosY = 0;
+
+                        @Override
+                        public boolean onTouch(View v, MotionEvent event) {
+                            FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
+
+
+                            boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
+                            if (event.getAction() != MotionEvent.ACTION_MOVE && isSingleTapTouch) {
+                                if (tapToTakePicture) {
+                                    takePicture(0, 0);
+                                }
+                                return true;
+                            } else {
+                                if (dragEnabled) {
+                                    int x;
+                                    int y;
+
+                                    switch (event.getAction()) {
+                                        case MotionEvent.ACTION_DOWN:
+                                            if (mLastTouchX == 0 || mLastTouchY == 0) {
+                                                mLastTouchX = (int) event.getRawX() - layoutParams.leftMargin;
+                                                mLastTouchY = (int) event.getRawY() - layoutParams.topMargin;
+                                            } else {
+                                                mLastTouchX = (int) event.getRawX();
+                                                mLastTouchY = (int) event.getRawY();
+                                            }
+                                            break;
+                                        case MotionEvent.ACTION_MOVE:
+
+                                            x = (int) event.getRawX();
+                                            y = (int) event.getRawY();
+
+                                            final float dx = x - mLastTouchX;
+                                            final float dy = y - mLastTouchY;
+
+                                            mPosX += dx;
+                                            mPosY += dy;
+
+                                            layoutParams.leftMargin = mPosX;
+                                            layoutParams.topMargin = mPosY;
+
+                                            frameContainerLayout.setLayoutParams(layoutParams);
+
+                                            // Remember this touch position for the next move event
+                                            mLastTouchX = x;
+                                            mLastTouchY = y;
+
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                }
+                            }
+                            return true;
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    private void setDefaultCameraId() {
+
+        // Find the total number of cameras available
+        numberOfCameras = Camera.getNumberOfCameras();
+
+        int camId = defaultCamera.equals("front") ? Camera.CameraInfo.CAMERA_FACING_FRONT : Camera.CameraInfo.CAMERA_FACING_BACK;
+
+        // Find the ID of the default camera
+        Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
+        for (int i = 0; i < numberOfCameras; i++) {
+            Camera.getCameraInfo(i, cameraInfo);
+            if (cameraInfo.facing == camId) {
+                defaultCameraId = camId;
+                break;
             }
-          });
         }
-        catch(Exception e){
-          //An unexpected error occurred while saving the picture.
-          getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-              cameraLoader.setVisibility(View.INVISIBLE);
-              pictureView.setImageBitmap(null);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        mCamera = Camera.open(defaultCameraId);
+
+        if (cameraParameters != null) {
+            mCamera.setParameters(cameraParameters);
+        }
+
+        // set continuous autofocus
+        setFocusMode(currentFocusMode);
+        setFlashMode(currentFlashMode);
+
+        cameraCurrentlyLocked = defaultCameraId;
+
+        if (mPreview.mPreviewSize == null) {
+            mPreview.setCamera(mCamera, cameraCurrentlyLocked);
+        } else {
+            mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
+            mCamera.startPreview();
+        }
+
+        Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
+
+        final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
+        ViewTreeObserver viewTreeObserver = frameContainerLayout.getViewTreeObserver();
+        if (viewTreeObserver.isAlive()) {
+            viewTreeObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                    frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+                    final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage));
+
+                    FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(frameContainerLayout.getWidth(), frameContainerLayout.getHeight());
+                    camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
+                    frameCamContainerLayout.setLayoutParams(camViewLayout);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        // Because the Camera object is a shared resource, it's very
+        // important to release it when the activity is paused.
+        if (mCamera != null) {
+            mPreview.setCamera(null, -1);
+            mCamera.release();
+            mCamera = null;
+        }
+    }
+
+    Camera getCamera() {
+        return mCamera;
+    }
+
+    void switchCamera() {
+        // check for availability of multiple cameras
+        if (numberOfCameras == 1) {
+            //There is only one camera available
+            return;
+        }
+        Log.d(TAG, "numberOfCameras: " + numberOfCameras);
+
+        // OK, we have multiple cameras.
+        // Release this camera -> cameraCurrentlyLocked
+        if (mCamera != null) {
+            mCamera.stopPreview();
+            mPreview.setCamera(null, -1);
+            mCamera.release();
+            mCamera = null;
+        }
+
+        // Acquire the next camera and request Preview to reconfigure
+        // parameters.
+        mCamera = Camera.open((cameraCurrentlyLocked + 1) % numberOfCameras);
+
+        if (cameraParameters != null) {
+            mCamera.setParameters(cameraParameters);
+        }
+
+        cameraCurrentlyLocked = (cameraCurrentlyLocked + 1) % numberOfCameras;
+        mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
+
+        Log.d(TAG, "cameraCurrentlyLocked new: " + cameraCurrentlyLocked);
+
+        // Start the preview
+        mCamera.startPreview();
+    }
+
+    void setFlashMode(int flashMode) {
+
+        Camera.Parameters parameters = mCamera.getParameters();
+        List<String> supportedFlashModes = parameters.getSupportedFlashModes();
+
+        if (supportedFlashModes != null) {
+            if (flashMode == FLASH_OFF && supportedFlashModes.contains(Parameters.FLASH_MODE_OFF)) {
+                parameters.setFlashMode(Parameters.FLASH_MODE_OFF);
+            } else if (flashMode == FLASH_ON && supportedFlashModes.contains(Parameters.FLASH_MODE_ON)) {
+                parameters.setFlashMode(Parameters.FLASH_MODE_ON);
+            } else if (flashMode == FLASH_AUTO && supportedFlashModes.contains(Parameters.FLASH_MODE_AUTO)) {
+                parameters.setFlashMode(Parameters.FLASH_MODE_AUTO);
+            } else if (flashMode == FLASH_AUTO && supportedFlashModes.contains(Parameters.FLASH_MODE_ON)) {
+                parameters.setFlashMode(Parameters.FLASH_MODE_ON);
             }
-          });
-        }
-      }
-    }.start();
-  }
-
-  private File getOutputMediaFile(String suffix){
-
-    File mediaStorageDir = getActivity().getApplicationContext().getFilesDir();
-    /*if(Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED && Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED_READ_ONLY) {
-      mediaStorageDir = new File(Environment.getExternalStorageDirectory() + "/Android/data/" + getActivity().getApplicationContext().getPackageName() + "/Files");
-      }*/
-    if (! mediaStorageDir.exists()){
-      if (! mediaStorageDir.mkdirs()){
-        return null;
-      }
-    }
-    // Create a media file name
-    String timeStamp = new SimpleDateFormat("dd_MM_yyyy_HHmm_ss").format(new Date());
-    File mediaFile;
-    String mImageName = "camerapreview_" + timeStamp + suffix + ".jpg";
-    mediaFile = new File(mediaStorageDir.getPath() + File.separator + mImageName);
-    return mediaFile;
-  }
-
-  private File storeImage(Bitmap image, String suffix) {
-    File pictureFile = getOutputMediaFile(suffix);
-    if (pictureFile != null) {
-      try {
-        FileOutputStream fos = new FileOutputStream(pictureFile);
-        image.compress(Bitmap.CompressFormat.JPEG, 80, fos);
-        fos.close();
-        return pictureFile;
-      }
-      catch (Exception ex) {
-      }
-    }
-    return null;
-  }
-
-  public int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
-    // Raw height and width of image
-    final int height = options.outHeight;
-    final int width = options.outWidth;
-    int inSampleSize = 1;
-
-    if (height > reqHeight || width > reqWidth) {
-
-      final int halfHeight = height / 2;
-      final int halfWidth = width / 2;
-
-      // Calculate the largest inSampleSize value that is a power of 2 and keeps both
-      // height and width larger than the requested height and width.
-      while ((halfHeight / inSampleSize) > reqHeight && (halfWidth / inSampleSize) > reqWidth) {
-        inSampleSize *= 2;
-      }
-    }
-    return inSampleSize;
-  }
-
-  private Bitmap loadBitmapFromView(View v) {
-    Bitmap b = Bitmap.createBitmap( v.getMeasuredWidth(), v.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
-    Canvas c = new Canvas(b);
-    v.layout(v.getLeft(), v.getTop(), v.getRight(), v.getBottom());
-    v.draw(c);
-    return b;
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-  }
-}
-
-
-class Preview extends RelativeLayout implements SurfaceHolder.Callback {
-  private final String TAG = "Preview";
-
-  CustomSurfaceView mSurfaceView;
-  SurfaceHolder mHolder;
-  Camera.Size mPreviewSize;
-  List<Camera.Size> mSupportedPreviewSizes;
-  Camera mCamera;
-  int cameraId;
-  int displayOrientation;
-  int viewWidth;
-  int viewHeight;
-
-  Preview(Context context) {
-    super(context);
-
-    mSurfaceView = new CustomSurfaceView(context);
-    addView(mSurfaceView);
-
-    requestLayout();
-
-    // Install a SurfaceHolder.Callback so we get notified when the
-    // underlying surface is created and destroyed.
-    mHolder = mSurfaceView.getHolder();
-    mHolder.addCallback(this);
-    mHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
-  }
-
-  public void setCamera(Camera camera, int cameraId) {
-    mCamera = camera;
-    this.cameraId = cameraId;
-    if (mCamera != null) {
-      mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
-      setCameraDisplayOrientation();
-      //mCamera.getParameters().setRotation(getDisplayOrientation());
-      //requestLayout();
-    }
-  }
-
-  public int getDisplayOrientation() {
-    return displayOrientation;
-  }
-
-  private void setCameraDisplayOrientation() {
-    Camera.CameraInfo info=new Camera.CameraInfo();
-    int rotation=
-      ((Activity)getContext()).getWindowManager().getDefaultDisplay()
-      .getRotation();
-    int degrees=0;
-    DisplayMetrics dm=new DisplayMetrics();
-
-    Camera.getCameraInfo(cameraId, info);
-    ((Activity)getContext()).getWindowManager().getDefaultDisplay().getMetrics(dm);
-
-    switch (rotation) {
-      case Surface.ROTATION_0:
-        degrees=0;
-        break;
-      case Surface.ROTATION_90:
-        degrees=90;
-        break;
-      case Surface.ROTATION_180:
-        degrees=180;
-        break;
-      case Surface.ROTATION_270:
-        degrees=270;
-        break;
-    }
-
-    if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-      displayOrientation=(info.orientation + degrees) % 360;
-      displayOrientation=(360 - displayOrientation) % 360;
-    } else {
-      displayOrientation=(info.orientation - degrees + 360) % 360;
-    }
-
-    Log.d(TAG, "screen is rotated " + degrees + "deg from natural");
-    Log.d(TAG, (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT ? "front" : "back")
-        + " camera is oriented -" + info.orientation + "deg from natural");
-    Log.d(TAG, "need to rotate preview " + displayOrientation + "deg");
-    mCamera.setDisplayOrientation(displayOrientation);
-  }
-
-  public void switchCamera(Camera camera, int cameraId) {
-    setCamera(camera, cameraId);
-    mSupportedPreviewSizes = camera.getParameters().getSupportedPreviewSizes();
-    if (mSupportedPreviewSizes != null) {
-      mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, viewWidth, viewHeight);
-    }
-    try {
-      camera.setPreviewDisplay(mHolder);
-      Camera.Parameters parameters = camera.getParameters();
-      parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
-      camera.setParameters(parameters);
-    }
-    catch (IOException exception) {
-      Log.e(TAG, exception.getMessage());
-    }
-    //requestLayout();
-  }
-
-  @Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    // We purposely disregard child measurements because act as a
-    // wrapper to a SurfaceView that centers the camera preview instead
-    // of stretching it.
-    viewWidth = resolveSize(getSuggestedMinimumWidth(), widthMeasureSpec);
-    viewHeight = resolveSize(getSuggestedMinimumHeight(), heightMeasureSpec);
-    setMeasuredDimension(viewWidth, viewHeight);
-
-    if (mSupportedPreviewSizes != null) {
-      mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, viewWidth, viewHeight);
-      Log.i(TAG, "called supported sizes");
-    }
-  }
-
-  @Override
-  protected void onLayout(boolean changed, int l, int t, int r, int b) {
-
-    if (changed && getChildCount() > 0) {
-      final View child = getChildAt(0);
-
-      int width = r - l;
-      int height = b - t;
-
-      int previewWidth = width;
-      int previewHeight = height;
-
-      if (mPreviewSize != null) {
-        previewWidth = mPreviewSize.width;
-        previewHeight = mPreviewSize.height;
-
-        if(displayOrientation == 90 || displayOrientation == 270) {
-          previewWidth = mPreviewSize.height;
-          previewHeight = mPreviewSize.width;
+            mCamera.setParameters(parameters);
         }
 
-        LOG.d(TAG, "previewWidth:" + previewWidth + " previewHeight:" + previewHeight);
-      }
+        Log.d(TAG, "flashmode: " + flashMode);
 
-      int nW;
-      int nH;
-      int top;
-      int left;
-
-      float scale = 1.0f;
-
-      // Center the child SurfaceView within the parent.
-      if (width * previewHeight < height * previewWidth) {
-        Log.d(TAG, "center horizontally");
-        int scaledChildWidth = (int)((previewWidth * height / previewHeight) * scale);
-        nW = (width + scaledChildWidth) / 2;
-        nH = (int)(height * scale);
-        top = 0;
-        left = (width - scaledChildWidth) / 2;
-      }
-      else {
-        Log.d(TAG, "center vertically");
-        int scaledChildHeight = (int)((previewHeight * width / previewWidth) * scale);
-        nW = (int)(width * scale);
-        nH = (height + scaledChildHeight) / 2;
-        top = (height - scaledChildHeight) / 2;
-        left = 0;
-      }
-      child.layout(left, top, nW, nH);
-
-      Log.d("layout", "left:" + left);
-      Log.d("layout", "top:" + top);
-      Log.d("layout", "right:" + nW);
-      Log.d("layout", "bottom:" + nH);
-    }
-  }
-
-  public void surfaceCreated(SurfaceHolder holder) {
-    // The Surface has been created, acquire the camera and tell it where
-    // to draw.
-    try {
-      if (mCamera != null) {
-        mSurfaceView.setWillNotDraw(false);
-        mCamera.setPreviewDisplay(holder);
-      }
-    } catch (IOException exception) {
-      Log.e(TAG, "IOException caused by setPreviewDisplay()", exception);
-    }
-  }
-
-  public void surfaceDestroyed(SurfaceHolder holder) {
-    // Surface will be destroyed when we return, so stop the preview.
-    if (mCamera != null) {
-      mCamera.stopPreview();
-    }
-  }
-  private Camera.Size getOptimalPreviewSize(List<Camera.Size> sizes, int w, int h) {
-    final double ASPECT_TOLERANCE = 0.1;
-    double targetRatio = (double) w / h;
-    if (displayOrientation == 90 || displayOrientation == 270) {
-      targetRatio = (double) h / w;
-    }
-    if (sizes == null) return null;
-
-    Camera.Size optimalSize = null;
-    double minDiff = Double.MAX_VALUE;
-
-    int targetHeight = h;
-
-    // Try to find an size match aspect ratio and size
-    for (Camera.Size size : sizes) {
-      double ratio = (double) size.width / size.height;
-      if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE) continue;
-      if (Math.abs(size.height - targetHeight) < minDiff) {
-        optimalSize = size;
-        minDiff = Math.abs(size.height - targetHeight);
-      }
+        currentFlashMode = flashMode;
     }
 
-    // Cannot find the one match the aspect ratio, ignore the requirement
-    if (optimalSize == null) {
-      minDiff = Double.MAX_VALUE;
-      for (Camera.Size size : sizes) {
-        if (Math.abs(size.height - targetHeight) < minDiff) {
-          optimalSize = size;
-          minDiff = Math.abs(size.height - targetHeight);
+    private void setFocusMode(int focusMode) {
+        Camera.Parameters parameters = mCamera.getParameters();
+        List<String> supportedFocusModes = parameters.getSupportedFocusModes();
+
+        if (supportedFocusModes != null) {
+            if (focusMode == FOCUS_AUTO && supportedFocusModes.contains(Parameters.FOCUS_MODE_AUTO)) {
+                parameters.setFocusMode(Parameters.FOCUS_MODE_AUTO);
+            } else if (focusMode == FOCUS_CONTINUOUS && supportedFocusModes.contains(Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                parameters.setFocusMode(Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            }
+            mCamera.setParameters(parameters);
         }
-      }
+
+        Log.d(TAG, "focusMode: " + focusMode);
+
+        currentFocusMode = focusMode;
     }
 
-    Log.d(TAG, "optimal preview size: w: " + optimalSize.width + " h: " + optimalSize.height);
-    return optimalSize;
-  }
+    void setCameraParameters(Camera.Parameters params) {
+        cameraParameters = params;
 
-  public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
-    if(mCamera != null) {
-      // Now that the size is known, set up the camera parameters and begin
-      // the preview.
-      mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
-      if (mSupportedPreviewSizes != null) {
-        mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, w, h);
-      }
-      Camera.Parameters parameters = mCamera.getParameters();
-      parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
-      requestLayout();
-      //mCamera.setDisplayOrientation(90);
-      mCamera.setParameters(parameters);
-      mCamera.startPreview();
+        if (mCamera != null && cameraParameters != null) {
+            mCamera.setParameters(cameraParameters);
+        }
     }
-  }
 
-  public byte[] getFramePicture(byte[] data, Camera camera) {
-    Camera.Parameters parameters = camera.getParameters();
-    int format = parameters.getPreviewFormat();
+    void takePicture(final int maxWidth, final int maxHeight) {
+        if (mPreview != null) {
+            if (!canTakePicture)
+                return;
 
-    //YUV formats require conversion
-    if (format == ImageFormat.NV21 || format == ImageFormat.YUY2 || format == ImageFormat.NV16) {
-      int w = parameters.getPreviewSize().width;
-      int h = parameters.getPreviewSize().height;
+            canTakePicture = false;
 
-      // Get the YuV image
-      YuvImage yuvImage = new YuvImage(data, format, w, h, null);
-      // Convert YuV to Jpeg
-      Rect rect = new Rect(0, 0, w, h);
-      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      yuvImage.compressToJpeg(rect, 80, outputStream);
-      return outputStream.toByteArray();
+            PictureCallback mPicture = new PictureCallback() {
+                @Override
+                public void onPictureTaken(byte[] data, Camera camera) {
+                    Bitmap picture = BitmapFactory.decodeByteArray(data, 0, data.length);
+                    Matrix matrix = new Matrix();
+
+                    if (cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                        Log.d(TAG, "mirror y axis");
+                        matrix.preScale(-1.0f, 1.0f);
+                    }
+
+                    matrix.postRotate(mPreview.getDisplayOrientation());
+
+                    int pictureWidth = picture.getWidth();
+                    int pictureHeight = picture.getHeight();
+                    double pictureRatio = pictureWidth / (double) pictureHeight;
+
+                    // rotate to screen orientation
+                    try {
+                        picture = Bitmap.createBitmap(picture, 0, 0, pictureWidth, pictureHeight, matrix, true);
+
+                        pictureWidth = picture.getWidth();
+                        pictureHeight = picture.getHeight();
+                        pictureRatio = pictureWidth / (double) pictureHeight;
+                    } catch (OutOfMemoryError oom) {
+                        // You can run out of memory if the image is very large:
+                        // http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html
+                        // If this happens, simply do not rotate the image and return it unmodified.
+                        // If you do not catch the OutOfMemoryError, the Android app crashes.
+                    }
+
+                    // crop to match view
+                    try {
+                        ImageView pictureView = (ImageView) view.findViewById(getResources().getIdentifier("picture_view", "id", appResourcesPackage));
+                        double viewRatio = pictureView.getWidth() / (double) pictureView.getHeight();
+                        if (pictureRatio != viewRatio) {
+                            if (width / viewRatio > height) {
+                                height = pictureHeight;
+                                width = (int) Math.round(height * viewRatio);
+                            } else {
+                                width = pictureWidth;
+                                height = (int) Math.round(width / viewRatio);
+                            }
+
+                            Bitmap work = Bitmap.createBitmap(width, height, picture.getConfig());
+                            Canvas canvas = new Canvas(work);
+                            canvas.drawBitmap(picture, (width - pictureWidth) / 2, (height - pictureHeight) / 2, null);
+                            picture = work;
+
+                            pictureWidth = width;
+                            pictureHeight = height;
+                            pictureRatio = width / (double) height;
+                        }
+                    } catch (OutOfMemoryError oom) {
+                        // You can run out of memory if the image is very large:
+                        // http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html
+                        // If this happens, simply do not crop the image and return it unmodified.
+                        // If you do not catch the OutOfMemoryError, the Android app crashes.
+                    }
+
+                    // scale to fit within bounds
+                    if (maxWidth != 0 || maxHeight != 0) {
+                        try {
+                            int width = maxWidth < 0 ? pictureWidth : maxWidth;
+                            int height = maxHeight < 0 ? pictureHeight : maxHeight;
+
+                            // swap max dimension to match image orientation
+                            if ((pictureWidth < pictureHeight && width > height) || (pictureWidth > pictureHeight && width < height)) {
+                                int tmp = width;
+                                width = height;
+                                height = tmp;
+                            }
+
+                            // set other dimension to match if only one is defined
+                            if (width != 0 && height == 0) {
+                                height = (int) Math.round(width / pictureRatio);
+                            } else if (height != 0 && width == 0) {
+                                width = (int) Math.round(height * pictureRatio);
+                            }
+
+                            // scale image if it exceeds the requested size
+                            if (width > 0 && height > 0 && (pictureWidth > width || pictureHeight > height)) {
+                                if (width / pictureRatio > height) {
+                                    width = (int) Math.round(height * pictureRatio);
+                                } else {
+                                    height = (int) Math.round(width / pictureRatio);
+                                }
+
+                                picture = Bitmap.createScaledBitmap(picture, width, height, false);
+                            }
+                        } catch (OutOfMemoryError oom) {
+                            // You can run out of memory if the image is very large:
+                            // http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html
+                            // If this happens, simply do not scale the image and return it unmodified.
+                            // If you do not catch the OutOfMemoryError, the Android app crashes.
+                        }
+                    }
+
+                    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                    picture.compress(Bitmap.CompressFormat.JPEG, 85, byteArrayOutputStream);
+                    byte[] byteArray = byteArrayOutputStream.toByteArray();
+
+                    String encodedImage = Base64.encodeToString(byteArray, Base64.NO_WRAP);
+
+                    eventListener.onPictureTaken(encodedImage);
+                    canTakePicture = true;
+                }
+            };
+
+            mCamera.takePicture(null, null, mPicture);
+        } else {
+            canTakePicture = true;
+        }
     }
-    return data;
-  }
-  public void setOneShotPreviewCallback(Camera.PreviewCallback callback) {
-    if(mCamera != null) {
-      mCamera.setOneShotPreviewCallback(callback);
+
+//  public boolean hasFrontCamera(){
+//    return getActivity().getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
+//  }
+
+//  public Bitmap cropBitmap(Bitmap bitmap, Rect rect){
+//    int w = rect.right - rect.left;
+//    int h = rect.bottom - rect.top;
+//    Bitmap ret = Bitmap.createBitmap(w, h, bitmap.getConfig());
+//    Canvas canvas= new Canvas(ret);
+//    canvas.drawBitmap(bitmap, -rect.left, -rect.top, null);
+//    return ret;
+//  }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
     }
-  }
-}
-class TapGestureDetector extends GestureDetector.SimpleOnGestureListener{
 
-  @Override
-  public boolean onDown(MotionEvent e) {
-    return false;
-  }
+//  private void generatePictureFromView(final Bitmap originalPicture, final Bitmap picture){
+//
+//    final FrameLayout cameraLoader = (FrameLayout)view.findViewById(getResources().getIdentifier("camera_loader", "id", appResourcesPackage));
+//    cameraLoader.setVisibility(View.VISIBLE);
+//    final ImageView pictureView = (ImageView) view.findViewById(getResources().getIdentifier("picture_view", "id", appResourcesPackage));
+//    new Thread() {
+//      public void run() {
+//
+//        try {
+//          final File picFile = storeImage(picture, "_preview");
+//          final File originalPictureFile = storeImage(originalPicture, "_original");
+//
+//          eventListener.onPictureTaken(originalPictureFile.getAbsolutePath());
+//
+//          getActivity().runOnUiThread(new Runnable() {
+//            @Override
+//            public void run() {
+//              cameraLoader.setVisibility(View.INVISIBLE);
+//              pictureView.setImageBitmap(null);
+//            }
+//          });
+//        }
+//        catch(Exception e){
+//          //An unexpected error occurred while saving the picture.
+//          getActivity().runOnUiThread(new Runnable() {
+//            @Override
+//            public void run() {
+//              cameraLoader.setVisibility(View.INVISIBLE);
+//              pictureView.setImageBitmap(null);
+//            }
+//          });
+//        }
+//      }
+//    }.start();
+//  }
 
-  @Override
-  public boolean onSingleTapUp(MotionEvent e) {
-    return true;
-  }
+//  private File getOutputMediaFile(String suffix){
+//
+//    File mediaStorageDir = getActivity().getApplicationContext().getFilesDir();
+//    /*if(Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED && Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED_READ_ONLY) {
+//      mediaStorageDir = new File(Environment.getExternalStorageDirectory() + "/Android/data/" + getActivity().getApplicationContext().getPackageName() + "/Files");
+//      }*/
+//    if (! mediaStorageDir.exists()){
+//      if (! mediaStorageDir.mkdirs()){
+//        return null;
+//      }
+//    }
+//    // Create a media file name
+//    String timeStamp = new SimpleDateFormat("dd_MM_yyyy_HHmm_ss").format(new Date());
+//    File mediaFile;
+//    String mImageName = "camerapreview_" + timeStamp + suffix + ".jpg";
+//    mediaFile = new File(mediaStorageDir.getPath() + File.separator + mImageName);
+//    return mediaFile;
+//  }
 
-  @Override
-  public boolean onSingleTapConfirmed(MotionEvent e) {
-    return true;
-  }
-}
-class CustomSurfaceView extends SurfaceView implements SurfaceHolder.Callback{
-  private final String TAG = "CustomSurfaceView";
+//  private File storeImage(Bitmap image, String suffix) {
+//    File pictureFile = getOutputMediaFile(suffix);
+//    if (pictureFile != null) {
+//      try {
+//        FileOutputStream fos = new FileOutputStream(pictureFile);
+//        image.compress(Bitmap.CompressFormat.JPEG, 80, fos);
+//        fos.close();
+//        return pictureFile;
+//      }
+//      catch (Exception ex) {
+//      }
+//    }
+//    return null;
+//  }
 
-  CustomSurfaceView(Context context){
-    super(context);
-  }
+//  public int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
+//    // Raw height and width of image
+//    final int height = options.outHeight;
+//    final int width = options.outWidth;
+//    int inSampleSize = 1;
+//
+//    if (height > reqHeight || width > reqWidth) {
+//
+//      final int halfHeight = height / 2;
+//      final int halfWidth = width / 2;
+//
+//      // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+//      // height and width larger than the requested height and width.
+//      while ((halfHeight / inSampleSize) > reqHeight && (halfWidth / inSampleSize) > reqWidth) {
+//        inSampleSize *= 2;
+//      }
+//    }
+//    return inSampleSize;
+//  }
 
-  @Override
-  public void surfaceCreated(SurfaceHolder holder) {
-  }
+//  private Bitmap loadBitmapFromView(View v) {
+//    Bitmap b = Bitmap.createBitmap( v.getMeasuredWidth(), v.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+//    Canvas c = new Canvas(b);
+//    v.layout(v.getLeft(), v.getTop(), v.getRight(), v.getBottom());
+//    v.draw(c);
+//    return b;
+//  }
 
-  @Override
-  public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-  }
-
-  @Override
-  public void surfaceDestroyed(SurfaceHolder holder) {
-  }
+    interface CameraPreviewListener {
+        void onPictureTaken(String originalPicturePath);
+    }
 }

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -159,9 +159,9 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     pluginResult.setKeepCallback(true);
     callbackContext.sendPluginResult(pluginResult);
     try {
-      double maxWidth = args.getDouble(0);
-      double maxHeight = args.getDouble(1);
-      fragment.takePicture(maxWidth, maxHeight);
+      double maxWidth = args.optDouble(0, 0);
+      double maxHeight = args.optDouble(1, 0);
+      fragment.takePicture((int)Math.floor(maxWidth), (int)Math.floor(maxHeight));
     }
     catch(Exception e){
       e.printStackTrace();

--- a/src/android/CustomSurfaceView.java
+++ b/src/android/CustomSurfaceView.java
@@ -1,0 +1,25 @@
+package com.cordovaplugincamerapreview;
+
+import android.content.Context;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+
+class CustomSurfaceView extends SurfaceView implements SurfaceHolder.Callback{
+    private final String TAG = "CustomSurfaceView";
+
+    CustomSurfaceView(Context context){
+        super(context);
+    }
+
+    @Override
+    public void surfaceCreated(SurfaceHolder holder) {
+    }
+
+    @Override
+    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+    }
+
+    @Override
+    public void surfaceDestroyed(SurfaceHolder holder) {
+    }
+}

--- a/src/android/Preview.java
+++ b/src/android/Preview.java
@@ -1,0 +1,292 @@
+package com.cordovaplugincamerapreview;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.ImageFormat;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.hardware.Camera;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.View;
+import android.widget.RelativeLayout;
+import org.apache.cordova.LOG;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+class Preview extends RelativeLayout implements SurfaceHolder.Callback {
+    private final String TAG = "Preview";
+
+    CustomSurfaceView mSurfaceView;
+    SurfaceHolder mHolder;
+    Camera.Size mPreviewSize;
+    List<Camera.Size> mSupportedPreviewSizes;
+    Camera mCamera;
+    int cameraId;
+    int displayOrientation;
+    int viewWidth;
+    int viewHeight;
+
+    Preview(Context context) {
+        super(context);
+
+        mSurfaceView = new CustomSurfaceView(context);
+        addView(mSurfaceView);
+
+        requestLayout();
+
+        // Install a SurfaceHolder.Callback so we get notified when the
+        // underlying surface is created and destroyed.
+        mHolder = mSurfaceView.getHolder();
+        mHolder.addCallback(this);
+        mHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
+    }
+
+    public void setCamera(Camera camera, int cameraId) {
+        mCamera = camera;
+        this.cameraId = cameraId;
+        if (mCamera != null) {
+            mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
+            setCameraDisplayOrientation();
+            //mCamera.getParameters().setRotation(getDisplayOrientation());
+            //requestLayout();
+        }
+    }
+
+    public int getDisplayOrientation() {
+        return displayOrientation;
+    }
+
+    private void setCameraDisplayOrientation() {
+        Camera.CameraInfo info=new Camera.CameraInfo();
+        int rotation=
+                ((Activity)getContext()).getWindowManager().getDefaultDisplay()
+                        .getRotation();
+        int degrees=0;
+        DisplayMetrics dm=new DisplayMetrics();
+
+        Camera.getCameraInfo(cameraId, info);
+        ((Activity)getContext()).getWindowManager().getDefaultDisplay().getMetrics(dm);
+
+        switch (rotation) {
+            case Surface.ROTATION_0:
+                degrees=0;
+                break;
+            case Surface.ROTATION_90:
+                degrees=90;
+                break;
+            case Surface.ROTATION_180:
+                degrees=180;
+                break;
+            case Surface.ROTATION_270:
+                degrees=270;
+                break;
+        }
+
+        if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+            displayOrientation=(info.orientation + degrees) % 360;
+            displayOrientation=(360 - displayOrientation) % 360;
+        } else {
+            displayOrientation=(info.orientation - degrees + 360) % 360;
+        }
+
+        Log.d(TAG, "screen is rotated " + degrees + "deg from natural");
+        Log.d(TAG, (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT ? "front" : "back")
+                + " camera is oriented -" + info.orientation + "deg from natural");
+        Log.d(TAG, "need to rotate preview " + displayOrientation + "deg");
+        mCamera.setDisplayOrientation(displayOrientation);
+    }
+
+    public void switchCamera(Camera camera, int cameraId) {
+        setCamera(camera, cameraId);
+        mSupportedPreviewSizes = camera.getParameters().getSupportedPreviewSizes();
+        if (mSupportedPreviewSizes != null) {
+            mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, viewWidth, viewHeight);
+        }
+        try {
+            camera.setPreviewDisplay(mHolder);
+            Camera.Parameters parameters = camera.getParameters();
+            parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
+            camera.setParameters(parameters);
+        }
+        catch (IOException exception) {
+            Log.e(TAG, exception.getMessage());
+        }
+        //requestLayout();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        // We purposely disregard child measurements because act as a
+        // wrapper to a SurfaceView that centers the camera preview instead
+        // of stretching it.
+        viewWidth = resolveSize(getSuggestedMinimumWidth(), widthMeasureSpec);
+        viewHeight = resolveSize(getSuggestedMinimumHeight(), heightMeasureSpec);
+        setMeasuredDimension(viewWidth, viewHeight);
+
+        if (mSupportedPreviewSizes != null) {
+            mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, viewWidth, viewHeight);
+            Log.i(TAG, "called supported sizes");
+        }
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+
+        if (changed && getChildCount() > 0) {
+            final View child = getChildAt(0);
+
+            int width = r - l;
+            int height = b - t;
+
+            int previewWidth = width;
+            int previewHeight = height;
+
+            if (mPreviewSize != null) {
+                previewWidth = mPreviewSize.width;
+                previewHeight = mPreviewSize.height;
+
+                if(displayOrientation == 90 || displayOrientation == 270) {
+                    previewWidth = mPreviewSize.height;
+                    previewHeight = mPreviewSize.width;
+                }
+
+                LOG.d(TAG, "previewWidth:" + previewWidth + " previewHeight:" + previewHeight);
+            }
+
+            int nW;
+            int nH;
+            int top;
+            int left;
+
+            float scale = 1.0f;
+
+            // Center the child SurfaceView within the parent.
+            if (width * previewHeight < height * previewWidth) {
+                Log.d(TAG, "center horizontally");
+                int scaledChildWidth = (int)((previewWidth * height / previewHeight) * scale);
+                nW = (width + scaledChildWidth) / 2;
+                nH = (int)(height * scale);
+                top = 0;
+                left = (width - scaledChildWidth) / 2;
+            }
+            else {
+                Log.d(TAG, "center vertically");
+                int scaledChildHeight = (int)((previewHeight * width / previewWidth) * scale);
+                nW = (int)(width * scale);
+                nH = (height + scaledChildHeight) / 2;
+                top = (height - scaledChildHeight) / 2;
+                left = 0;
+            }
+            child.layout(left, top, nW, nH);
+
+            Log.d("layout", "left:" + left);
+            Log.d("layout", "top:" + top);
+            Log.d("layout", "right:" + nW);
+            Log.d("layout", "bottom:" + nH);
+        }
+    }
+
+    public void surfaceCreated(SurfaceHolder holder) {
+        // The Surface has been created, acquire the camera and tell it where
+        // to draw.
+        try {
+            if (mCamera != null) {
+                mSurfaceView.setWillNotDraw(false);
+                mCamera.setPreviewDisplay(holder);
+            }
+        } catch (IOException exception) {
+            Log.e(TAG, "IOException caused by setPreviewDisplay()", exception);
+        }
+    }
+
+    public void surfaceDestroyed(SurfaceHolder holder) {
+        // Surface will be destroyed when we return, so stop the preview.
+        if (mCamera != null) {
+            mCamera.stopPreview();
+        }
+    }
+    private Camera.Size getOptimalPreviewSize(List<Camera.Size> sizes, int w, int h) {
+        final double ASPECT_TOLERANCE = 0.1;
+        double targetRatio = (double) w / h;
+        if (displayOrientation == 90 || displayOrientation == 270) {
+            targetRatio = (double) h / w;
+        }
+        if (sizes == null) return null;
+
+        Camera.Size optimalSize = null;
+        double minDiff = Double.MAX_VALUE;
+
+        int targetHeight = h;
+
+        // Try to find an size match aspect ratio and size
+        for (Camera.Size size : sizes) {
+            double ratio = (double) size.width / size.height;
+            if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE) continue;
+            if (Math.abs(size.height - targetHeight) < minDiff) {
+                optimalSize = size;
+                minDiff = Math.abs(size.height - targetHeight);
+            }
+        }
+
+        // Cannot find the one match the aspect ratio, ignore the requirement
+        if (optimalSize == null) {
+            minDiff = Double.MAX_VALUE;
+            for (Camera.Size size : sizes) {
+                if (Math.abs(size.height - targetHeight) < minDiff) {
+                    optimalSize = size;
+                    minDiff = Math.abs(size.height - targetHeight);
+                }
+            }
+        }
+
+        Log.d(TAG, "optimal preview size: w: " + optimalSize.width + " h: " + optimalSize.height);
+        return optimalSize;
+    }
+
+    public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
+        if(mCamera != null) {
+            // Now that the size is known, set up the camera parameters and begin
+            // the preview.
+            mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
+            if (mSupportedPreviewSizes != null) {
+                mPreviewSize = getOptimalPreviewSize(mSupportedPreviewSizes, w, h);
+            }
+            Camera.Parameters parameters = mCamera.getParameters();
+            parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
+            requestLayout();
+            //mCamera.setDisplayOrientation(90);
+            mCamera.setParameters(parameters);
+            mCamera.startPreview();
+        }
+    }
+
+    public byte[] getFramePicture(byte[] data, Camera camera) {
+        Camera.Parameters parameters = camera.getParameters();
+        int format = parameters.getPreviewFormat();
+
+        //YUV formats require conversion
+        if (format == ImageFormat.NV21 || format == ImageFormat.YUY2 || format == ImageFormat.NV16) {
+            int w = parameters.getPreviewSize().width;
+            int h = parameters.getPreviewSize().height;
+
+            // Get the YuV image
+            YuvImage yuvImage = new YuvImage(data, format, w, h, null);
+            // Convert YuV to Jpeg
+            Rect rect = new Rect(0, 0, w, h);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            yuvImage.compressToJpeg(rect, 80, outputStream);
+            return outputStream.toByteArray();
+        }
+        return data;
+    }
+    public void setOneShotPreviewCallback(Camera.PreviewCallback callback) {
+        if(mCamera != null) {
+            mCamera.setOneShotPreviewCallback(callback);
+        }
+    }
+}

--- a/src/android/TapGestureDetector.java
+++ b/src/android/TapGestureDetector.java
@@ -1,0 +1,22 @@
+package com.cordovaplugincamerapreview;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+class TapGestureDetector extends GestureDetector.SimpleOnGestureListener{
+
+    @Override
+    public boolean onDown(MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onSingleTapUp(MotionEvent e) {
+        return true;
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent e) {
+        return true;
+    }
+}


### PR DESCRIPTION
Currently the resulting image is scaled to match the preview window, this results in poor results on low-res devices with a high quality camera. I updated the android code as follows:

1) First rotate/flip the image to match the display orientation and facing
2) Crop the image to match the same aspect ratio as the preview (center crop)
3) Scale the image to fit within the bounds defined by maxWidth/maxHeight

I also did a bit of cleanup and made separate files for the classes that were embedded within the CameraActivity.java file (coding style suggests one class per file)...
